### PR TITLE
일정 반복기능 추

### DIFF
--- a/src/main/java/com/codingbottle/calendar/domain/daterepeater/DateRepeater.java
+++ b/src/main/java/com/codingbottle/calendar/domain/daterepeater/DateRepeater.java
@@ -1,9 +1,12 @@
 package com.codingbottle.calendar.domain.daterepeater;
 
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
 
+@NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public class DateRepeater {
     static final int EVERY_WEEK = 1;
     static final int EVERY_TWO_WEEKS = 2;
@@ -20,7 +23,7 @@ public class DateRepeater {
     }
 
     private static List<LocalDate> repeatByWeek(LocalDate startDate, int weekInterval, int repeatCount) {
-        return IntStream.range(0, repeatCount)
+        return IntStream.rangeClosed(0, repeatCount)
                 .mapToObj(i -> startDate.plusWeeks(weekInterval * i))
                 .toList();
     }

--- a/src/main/java/com/codingbottle/calendar/domain/daterepeater/DateRepeater.java
+++ b/src/main/java/com/codingbottle/calendar/domain/daterepeater/DateRepeater.java
@@ -1,0 +1,29 @@
+package com.codingbottle.calendar.domain.daterepeater;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
+
+public class DateRepeater {
+    static final int EVERY_WEEK = 1;
+    static final int EVERY_TWO_WEEKS = 2;
+    static final int EVERY_FOUR_WEEKS = 4;
+
+    public static List<LocalDate> repeat(LocalDate startDate, RepeatInterval repeatInterval, int repeatCount) {
+        // repeatInterval에 따라 startDate부터 repeatCount만큼 반복한 날짜들을 List에 담아 반환한다.
+        return switch (repeatInterval) {
+            case EVERY_WEEK -> repeatByWeek(startDate, EVERY_WEEK,  repeatCount);
+            case EVERY_TWO_WEEKS -> repeatByWeek(startDate, EVERY_TWO_WEEKS,  repeatCount);
+            case EVERY_FOUR_WEEKS -> repeatByWeek(startDate, EVERY_FOUR_WEEKS,  repeatCount);
+            default -> throw new IllegalArgumentException("지원하지 않는 반복구간입니다.");
+        };
+    }
+
+    private static List<LocalDate> repeatByWeek(LocalDate startDate, int weekInterval, int repeatCount) {
+        return IntStream.range(0, repeatCount)
+                .mapToObj(i -> startDate.plusWeeks(weekInterval * i))
+                .toList();
+    }
+
+
+}

--- a/src/main/java/com/codingbottle/calendar/domain/daterepeater/RepeatInterval.java
+++ b/src/main/java/com/codingbottle/calendar/domain/daterepeater/RepeatInterval.java
@@ -1,6 +1,11 @@
 package com.codingbottle.calendar.domain.daterepeater;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public enum RepeatInterval {
-    EVERY_WEEK, EVERY_TWO_WEEKS, EVERY_FOUR_WEEKS
+    EVERY_WEEK("매주마다"), EVERY_TWO_WEEKS("격주마다")
+    , EVERY_FOUR_WEEKS("4주마다");
     ;
+    public final String description;
 }

--- a/src/main/java/com/codingbottle/calendar/domain/daterepeater/RepeatInterval.java
+++ b/src/main/java/com/codingbottle/calendar/domain/daterepeater/RepeatInterval.java
@@ -1,0 +1,6 @@
+package com.codingbottle.calendar.domain.daterepeater;
+
+public enum RepeatInterval {
+    EVERY_WEEK, EVERY_TWO_WEEKS, EVERY_FOUR_WEEKS
+    ;
+}

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/controller/ScheduleController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
@@ -25,14 +26,16 @@ public class ScheduleController {
     // 특정 날짜에 일정 등록
     @PostMapping("/schedules")
     public ResponseEntity<RspTemplate<Void>> handleCreate(
-            @RequestBody ScheduleCreateReqDto reqDto,
+            @RequestBody @Validated ScheduleCreateReqDto reqDto,
             Authentication authentication
     ) {
         scheduleService.create(reqDto, Long.parseLong(authentication.getName()));
 
-        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.CREATED,
-                reqDto.date().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
-                        + " 일정 생성");
+        String rspMessage = reqDto.targetDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+                + " 일정 생성. 반복주기: "
+                + reqDto.repeatInterval().description != null ? reqDto.repeatInterval().description : "없음"
+                + ", 반복횟수: " + reqDto.repeatCount() + "회";
+        RspTemplate<Void> rspTemplate = new RspTemplate<>(HttpStatus.CREATED, rspMessage);
         return ResponseEntity.status(HttpStatus.CREATED).body(rspTemplate);
     }
 

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/dto/ScheduleCreateReqDto.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/dto/ScheduleCreateReqDto.java
@@ -1,5 +1,6 @@
 package com.codingbottle.calendar.domain.schedule.dto;
 
+import com.codingbottle.calendar.domain.daterepeater.RepeatInterval;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 
@@ -13,12 +14,16 @@ public record ScheduleCreateReqDto(
         String title,
         @JsonFormat(pattern = "yyyy-MM-dd", shape = Shape.STRING)
         @NotNull
-        LocalDate date,
+        LocalDate targetDate,
         @NotNull(message = "종일 여부를 입력해주세요.")
         Boolean isAllDay,
         @JsonFormat(pattern = "HH:mm", shape = Shape.STRING)
         LocalTime startTime,
         @JsonFormat(pattern = "HH:mm", shape = Shape.STRING)
-        LocalTime endTime
+        LocalTime endTime,
+
+        // 반복주기 repeatInterval을 반복횟수 repeatCount만큼 반복한다.
+        RepeatInterval repeatInterval,
+        Integer repeatCount
 ) {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
         format_sql: true
         default_batch_fetch_size: 100
+    open-in-view: false
 
 jwt:
   key: ${JWT_SECRET_KEY}

--- a/src/test/java/com/codingbottle/calendar/domain/daterepeater/DateRepeaterTest.java
+++ b/src/test/java/com/codingbottle/calendar/domain/daterepeater/DateRepeaterTest.java
@@ -14,7 +14,7 @@ class DateRepeaterTest {
     void 날짜를_반복간격_기준으로_반복횟수만큼_더하여_반환할_수_있다() {
         //given
         LocalDate startDate = LocalDate.of(2021, 1, 1);
-        int repeatCount = 3;
+        int repeatCount = 2;
 
         List<LocalDate> expectedDatesWithEveryWeeks = Arrays.asList(
                 LocalDate.of(2021, 1, 1),

--- a/src/test/java/com/codingbottle/calendar/domain/daterepeater/DateRepeaterTest.java
+++ b/src/test/java/com/codingbottle/calendar/domain/daterepeater/DateRepeaterTest.java
@@ -1,0 +1,48 @@
+package com.codingbottle.calendar.domain.daterepeater;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateRepeaterTest {
+
+    @Test
+    void 날짜를_반복간격_기준으로_반복횟수만큼_더하여_반환할_수_있다() {
+        //given
+        LocalDate startDate = LocalDate.of(2021, 1, 1);
+        int repeatCount = 3;
+
+        List<LocalDate> expectedDatesWithEveryWeeks = Arrays.asList(
+                LocalDate.of(2021, 1, 1),
+                LocalDate.of(2021, 1, 8),
+                LocalDate.of(2021, 1, 15)
+        );
+
+        List<LocalDate> expectedDatesWithEveryTwoWeeks = Arrays.asList(
+                LocalDate.of(2021, 1, 1),
+                LocalDate.of(2021, 1, 15),
+                LocalDate.of(2021, 1, 29)
+        );
+
+        List<LocalDate> expectedDatesWithEveryFourWeeks = Arrays.asList(
+                LocalDate.of(2021, 1, 1),
+                LocalDate.of(2021, 1, 29),
+                LocalDate.of(2021, 2, 26)
+        );
+
+        //when
+        List<LocalDate> resultsEveryWeeks = DateRepeater.repeat(startDate, RepeatInterval.EVERY_WEEK, repeatCount);
+        List<LocalDate> resultsTwoWeeks = DateRepeater.repeat(startDate, RepeatInterval.EVERY_TWO_WEEKS, repeatCount);
+        List<LocalDate> resultsFourWeeks = DateRepeater.repeat(startDate, RepeatInterval.EVERY_FOUR_WEEKS, repeatCount);
+
+        //then
+        assertThat(resultsEveryWeeks).isEqualTo(expectedDatesWithEveryWeeks);
+        assertThat(resultsTwoWeeks).isEqualTo(expectedDatesWithEveryTwoWeeks);
+        assertThat(resultsFourWeeks).isEqualTo(expectedDatesWithEveryFourWeeks);
+    }
+
+}


### PR DESCRIPTION
## 요약
- 일정 반복기능 추가 `@PostMapping("/schedules")`
`반복단위 'RepeatInterval'을'RepeatCount' 만큼 반복할 수 있다.`
이는 ScheduleCreateReqDto에서 볼 수 있으며, 
필수 입력 필드는 아니고 요청자가 선택해서 보낼 수 있는 필드임.

## 추가사항
- 반복기능을 위한 클래스
  - DateRepeater와 테스트 DateRepeaterTest 추가
  - 반복 단위 RepeatInterval enum 클래스 추가

## 수정사항
- ScheduleService 로직 변경, Request Dto에 필드 추가, 날짜 필드명 'date' -> 'startDate'