### PR TITLE
일정 매일반복기능, 주간일정 조회 등 Schedule 기능 보완 완료

### DIFF
--- a/src/main/java/com/codingbottle/calendar/domain/daterepeater/RepeatInterval.java
+++ b/src/main/java/com/codingbottle/calendar/domain/daterepeater/RepeatInterval.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public enum RepeatInterval {
-    EVERY_WEEK("매주마다"), EVERY_TWO_WEEKS("격주마다")
+    EVERY_DAY("매일") ,EVERY_WEEK("매주마다"), EVERY_TWO_WEEKS("격주마다")
     , EVERY_FOUR_WEEKS("4주마다");
-    ;
+
     public final String description;
 }

--- a/src/main/java/com/codingbottle/calendar/domain/daterepeater/ScheduleRepeater.java
+++ b/src/main/java/com/codingbottle/calendar/domain/daterepeater/ScheduleRepeater.java
@@ -20,6 +20,7 @@ public class ScheduleRepeater {
             case EVERY_WEEK -> repeatByWeek(scheduleToRepeat, EVERY_WEEK,  repeatCount);
             case EVERY_TWO_WEEKS -> repeatByWeek(scheduleToRepeat, EVERY_TWO_WEEKS,  repeatCount);
             case EVERY_FOUR_WEEKS -> repeatByWeek(scheduleToRepeat, EVERY_FOUR_WEEKS,  repeatCount);
+            case EVERY_DAY -> repeatByEveryDay(scheduleToRepeat, repeatCount);
             default -> throw new IllegalArgumentException("지원하지 않는 반복구간입니다.");
         };
     }
@@ -27,19 +28,34 @@ public class ScheduleRepeater {
     private static List<Schedule> repeatByWeek(Schedule scheduleToRepeat, int weekInterval, int repeatCount) {
         String repeatCode = UUID.randomUUID().toString();
         return IntStream.rangeClosed(0, repeatCount)
-                .mapToObj(i -> {
-                    return Schedule.builder()
-                            .member(scheduleToRepeat.getMember())
-                            .title(scheduleToRepeat.getTitle())
-                            .startDate(scheduleToRepeat.getStartDate().plusWeeks(weekInterval * i))
-                            .endDate(scheduleToRepeat.getEndDate().plusWeeks(weekInterval * i))
-                            .timeOfStartDate(scheduleToRepeat.getTimeOfStartDate())
-                            .timeOfEndDate(scheduleToRepeat.getTimeOfEndDate())
-                            .isAllDay(scheduleToRepeat.isAllDay())
-                            .isRepeat(true)
-                            .repeatCode(repeatCode)
-                            .build();
-                })
+                .mapToObj(i -> Schedule.builder()
+                        .member(scheduleToRepeat.getMember())
+                        .title(scheduleToRepeat.getTitle())
+                        .startDate(scheduleToRepeat.getStartDate().plusWeeks((long) weekInterval * i))
+                        .endDate(scheduleToRepeat.getEndDate().plusWeeks((long) weekInterval * i))
+                        .timeOfStartDate(scheduleToRepeat.getTimeOfStartDate())
+                        .timeOfEndDate(scheduleToRepeat.getTimeOfEndDate())
+                        .isAllDay(scheduleToRepeat.isAllDay())
+                        .isRepeat(true)
+                        .repeatCode(repeatCode)
+                        .build())
+                .toList();
+    }
+
+    private static List<Schedule> repeatByEveryDay(Schedule scheduleToRepeat, int repeatCount) {
+        String repeatCode = UUID.randomUUID().toString();
+        return IntStream.rangeClosed(0, repeatCount)
+                .mapToObj(i -> Schedule.builder()
+                        .member(scheduleToRepeat.getMember())
+                        .title(scheduleToRepeat.getTitle())
+                        .startDate(scheduleToRepeat.getStartDate().plusDays(i))
+                        .endDate(scheduleToRepeat.getEndDate().plusDays(i))
+                        .timeOfStartDate(scheduleToRepeat.getTimeOfStartDate())
+                        .timeOfEndDate(scheduleToRepeat.getTimeOfEndDate())
+                        .isAllDay(scheduleToRepeat.isAllDay())
+                        .isRepeat(true)
+                        .repeatCode(repeatCode)
+                        .build())
                 .toList();
     }
 }

--- a/src/main/java/com/codingbottle/calendar/domain/daterepeater/ScheduleRepeater.java
+++ b/src/main/java/com/codingbottle/calendar/domain/daterepeater/ScheduleRepeater.java
@@ -36,6 +36,7 @@ public class ScheduleRepeater {
                         .timeOfStartDate(scheduleToRepeat.getTimeOfStartDate())
                         .timeOfEndDate(scheduleToRepeat.getTimeOfEndDate())
                         .isAllDay(scheduleToRepeat.isAllDay())
+                        .colorCode(scheduleToRepeat.getColorCode())
                         .isRepeat(true)
                         .repeatCode(repeatCode)
                         .build())

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/controller/ScheduleController.java
@@ -7,6 +7,7 @@ import com.codingbottle.calendar.domain.schedule.entity.Schedule;
 import com.codingbottle.calendar.domain.schedule.service.ScheduleService;
 import com.codingbottle.calendar.global.api.RspTemplate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -81,6 +82,21 @@ public class ScheduleController {
         ScheduleListRspDto rspDto = ScheduleListRspDto.from(schedules);
         return new RspTemplate<>(HttpStatus.OK,
                 LocalDate.of(year, month, day) + " 일정목록",
+                rspDto);
+    }
+
+    // 두 날짜 사이의 일정 조회 (주간일정 조회에 사용)
+    @GetMapping("/schedules/start-date/{startDate}/end-date/{endDate}")
+    public RspTemplate<ScheduleListRspDto> handleGetSchedulesBetWeenTwoDays(
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate,
+            Authentication authentication
+    ) {
+        List<Schedule> schedules = scheduleService.findByStartDateToEndDate(startDate, endDate, Long.parseLong(authentication.getName()));
+
+        ScheduleListRspDto rspDto = ScheduleListRspDto.from(schedules);
+        return new RspTemplate<>(HttpStatus.OK,
+                startDate + "부터 " + endDate + "사이의 일정 목록",
                 rspDto);
     }
 

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/dto/ScheduleCreateReqDto.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/dto/ScheduleCreateReqDto.java
@@ -25,6 +25,7 @@ public record ScheduleCreateReqDto(
         @JsonFormat(pattern = "HH:mm", shape = Shape.STRING)
         LocalTime timeOfEndDate,
 
+        String colorCode,
         // 반복주기 repeatInterval을 반복횟수 repeatCount만큼 반복한다.
         RepeatInterval repeatInterval,
         Integer repeatCount

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/dto/ScheduleListRspDto.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/dto/ScheduleListRspDto.java
@@ -21,6 +21,7 @@ public class ScheduleListRspDto {
     static class ScheduleDto {
         long id;
         String title;
+        String colorCode;
 
         String startDate;
         String timeOfStartDate;
@@ -32,6 +33,7 @@ public class ScheduleListRspDto {
         ScheduleDto(Schedule schedule) {
             this.id = schedule.getId();
             this.title = schedule.getTitle();
+            this.colorCode = schedule.getColorCode();
 
             this.timeOfStartDate = schedule.getTimeOfStartDate() == null ? "" : schedule.getTimeOfStartDate().format(DateTimeFormatter.ofPattern("HH:mm"));
             this.timeOfEndDateTime = schedule.getTimeOfEndDate() == null ? "" : schedule.getTimeOfEndDate().format(DateTimeFormatter.ofPattern("HH:mm"));

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/dto/ScheduleUpdateReqDto.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/dto/ScheduleUpdateReqDto.java
@@ -17,13 +17,14 @@ public record ScheduleUpdateReqDto(
         @NotNull LocalDate endDate,
         @NotNull(message = "종일 여부를 입력해주세요.") Boolean isAllDay,
         @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING) LocalTime timeOfStartDate,
-        @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING) LocalTime timeOfEndDate
+        @JsonFormat(pattern = "HH:mm", shape = JsonFormat.Shape.STRING) LocalTime timeOfEndDate,
+        String colorCode
 ) {
     public Schedule toScheduleEntity(Member member) {
         if (isAllDay == null || !isAllDay) {
-            return Schedule.notAllDay(member, title, startDate, endDate, timeOfStartDate, timeOfEndDate);
+            return Schedule.notAllDay(member, title, startDate, endDate, timeOfStartDate, timeOfEndDate, colorCode);
         } else {
-            return Schedule.allDay(member, title, startDate, endDate);
+            return Schedule.allDay(member, title, startDate, endDate, colorCode);
         }
     }
 }

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/entity/Schedule.java
@@ -98,6 +98,10 @@ public class Schedule extends BaseTimeEntity {
             if (startDateTime.isAfter(endDateTime)) {
                 throw new IllegalStateException("시작시간이 종료시간보다 늦을 수 없습니다.");
             }
+            // 두 시간의 차이는 24시간 이내여야 함
+            if (startDateTime.plusHours(24).isBefore(endDateTime)) {
+                throw new IllegalStateException("종일 일정이 아닐 경우 시작시간과 종료시간의 차이는 24시간 이내여야 합니다.");
+            }
         }
 
         if (this.isAllDay &&

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/entity/Schedule.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/entity/Schedule.java
@@ -2,6 +2,7 @@ package com.codingbottle.calendar.domain.schedule.entity;
 
 import com.codingbottle.calendar.domain.common.BaseTimeEntity;
 import com.codingbottle.calendar.domain.member.entity.Member;
+import com.codingbottle.calendar.global.utils.ColorUtil;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,14 +28,15 @@ public class Schedule extends BaseTimeEntity {
     private LocalDate startDate;
     @Column(nullable = false)
     private LocalDate endDate;
-
     @Column(nullable = true)
     private LocalTime timeOfStartDate;
     @Column(nullable = true)
     private LocalTime timeOfEndDate;
-
     @Column(nullable = false)
     private boolean isAllDay;
+
+    @Column(nullable = false)
+    private String colorCode;
 
     @Column(nullable = false)
     private boolean isRepeat;
@@ -46,7 +48,7 @@ public class Schedule extends BaseTimeEntity {
     private Member member;
 
     public static Schedule notAllDay(Member member, String title, LocalDate startDate, LocalDate endDate
-            , LocalTime timeOfStartDate, LocalTime timeOfEndDate){
+            , LocalTime timeOfStartDate, LocalTime timeOfEndDate, String colorCode){
         return Schedule.builder()
                 .member(member)
                 .title(title)
@@ -55,29 +57,32 @@ public class Schedule extends BaseTimeEntity {
                 .timeOfStartDate(timeOfStartDate)
                 .timeOfEndDate(timeOfEndDate)
                 .isAllDay(false)
+                .colorCode(colorCode)
                 .isRepeat(false)
                 .build();
     }
 
-    public static Schedule allDay(Member member, String title, LocalDate startDate, LocalDate endDate){
+    public static Schedule allDay(Member member, String title, LocalDate startDate, LocalDate endDate, String colorCode){
         return Schedule.builder()
                 .member(member)
                 .title(title)
                 .startDate(startDate)
                 .endDate(endDate)
                 .isAllDay(true)
+                .colorCode(colorCode)
                 .isRepeat(false)
                 .build();
     }
 
     @Builder
-    private Schedule(String title, LocalDate startDate, LocalDate endDate, LocalTime timeOfStartDate, LocalTime timeOfEndDate, boolean isAllDay, boolean isRepeat, String repeatCode, Member member) {
+    private Schedule(String title, LocalDate startDate, LocalDate endDate, LocalTime timeOfStartDate, LocalTime timeOfEndDate, boolean isAllDay, String colorCode, boolean isRepeat, String repeatCode, Member member) {
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;
         this.timeOfStartDate = timeOfStartDate;
         this.timeOfEndDate = timeOfEndDate;
         this.isAllDay = isAllDay;
+        this.colorCode  = ColorUtil.isColorCode(colorCode) ? colorCode : ColorUtil.SCHEDULE_DEFAULT_COLOR_CODE; // 색상 미입력 시 기본 연분홍으로 결정됨
         this.isRepeat = isRepeat;
         this.repeatCode = repeatCode;
         this.member = member;

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/repository/ScheduleRepository.java
@@ -24,4 +24,14 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query("SELECT s.id FROM Schedule s WHERE s.repeatCode = :repeatCode")
     List<Long> findByRepeatCode(@Param("repeatCode") String repeatCode);
+
+    // startDate 혹은 endDate 파라미터 둘 중 하나라도 startDate와 endDate 사이에 있는 일정을 조회
+    @Query("SELECT s FROM Schedule s" +
+            " WHERE s.member.id = :memberId" +
+            " AND" +
+            " (:startDate BETWEEN s.startDate AND s.endDate" +
+            " OR" +
+            " :endDate BETWEEN s.startDate AND s.endDate)"
+    )
+    List<Schedule> findByStartDateToEndDate(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate, @Param("memberId") long memberId);
 }

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/service/ScheduleService.java
@@ -98,4 +98,11 @@ public class ScheduleService {
     public List<Schedule> findByYearAndMonth(int year, int month, long memberId) {
         return scheduleRepository.findByYearAndMonth(year, month, memberId);
     }
+
+    public List<Schedule> findByStartDateToEndDate(LocalDate startDate, LocalDate endDate, long memberId) {
+        if (startDate.isAfter(endDate)) {
+            throw new IllegalStateException("시작일이 종료일보다 늦을 수 없습니다.");
+        }
+        return scheduleRepository.findByStartDateToEndDate(startDate, endDate, memberId);
+    }
 }

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/service/ScheduleService.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/service/ScheduleService.java
@@ -30,6 +30,7 @@ public class ScheduleService {
         Integer repeatCount = reqDto.repeatCount();
         LocalDate startDate = reqDto.startDate();
         LocalDate endDate = reqDto.endDate();
+        String colorCode = reqDto.colorCode();
 
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NoSuchElementException("회원을 찾을 수 없습니다."));
@@ -37,9 +38,9 @@ public class ScheduleService {
         // 종일 여부 검사
         Schedule schedule;
         if (reqDto.isAllDay()) {
-            schedule = Schedule.allDay(member, title, startDate, endDate);
+            schedule = Schedule.allDay(member, title, startDate, endDate, colorCode);
         } else {
-            schedule = Schedule.notAllDay(member, title, startDate, endDate, reqDto.timeOfStartDate(), reqDto.timeOfEndDate());
+            schedule = Schedule.notAllDay(member, title, startDate, endDate, reqDto.timeOfStartDate(), reqDto.timeOfEndDate(), colorCode);
         }
 
         // 반복주기에 따라 단일 일정 or 반복 일정 생성

--- a/src/main/java/com/codingbottle/calendar/global/utils/ColorUtil.java
+++ b/src/main/java/com/codingbottle/calendar/global/utils/ColorUtil.java
@@ -1,0 +1,16 @@
+package com.codingbottle.calendar.global.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ColorUtil {
+    public static final String SCHEDULE_DEFAULT_COLOR_CODE = "EFE1E1";
+    public static boolean isColorCode(String str) {
+        if (! StringUtils.hasText(str)) {
+            return false;
+        }
+        return str.matches("^([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$");
+    }
+}


### PR DESCRIPTION
## 요약
- 일정 생성 24시 제약
- 주간일정 조회 API
- 일정생성 API에서 '매일 반복'기능 추가
- 색상코드 기능 추가

## 추가사항
1. 일정생성 API에서 '매일 반복'기능 추가
  - 일정생성 API에서 'RepeatInterval'주기로 'RepeatCount'회만큼 반복할 수 있는데, RepeatInterval에 '매일' 반복주기 추가함.
2. 일정 생성 24시 제약
  - 종일 일정이 아닌 경우 (endTime - startTime)이 24시 이내여야 함. 화면상 표시를 편하게 하기 위함.
3. 주간일정 조회 API
  - 시작일과 종료일을 입력받고, 그 사이에 속한 일정목록을 반환함.
4. 색상코드 기능 추가
  - Schedule 객체에 colorCode를 추가함(colorCode를 입력하지 않을 경우 기본색상으로 대체해서 저장)

## 수정사항
- X
