### PR TITLE
[Fix] 구글 캘린더 스케쥴 연동 수정

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -11,11 +11,11 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # JAVA 17 설정(corretto 배포)
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'corretto'


### PR DESCRIPTION
## 요약
- 구글 캘린더 스케쥴 연동 수정

## 추가사항
- 컬러 컬럼 연동 추가
- 종일이 아닌 스케쥴 중 두 시간이 24시간을 초과하는 스케쥴은 종일 일정으로 추가되도록 수정

## 수정사항
- docker git action은 v4버전이 없어 v3 버전으로 다운
