### PR TITLE
[Fix] docker git action 버전 다운

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -30,15 +30,15 @@ jobs:
 
       # 다중 아키텍쳐 배포를 위한 설정
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@v3
 
       # Buildx를 사용 설정
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v3
 
       # Docker 로그인
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}


### PR DESCRIPTION
## 요약
- docker git action은 v4버전이 없어 v3 버전으로 다운

## 추가사항
- 추가사항을 적어주세요.

## 수정사항
- docker git action은 v4버전이 없어 v3 버전으로 다운
