### PR TITLE
Fix. OAuth redirect path 오류 수정

### DIFF
--- a/src/main/java/com/codingbottle/calendar/domain/auth/handler/OAuth2MemberSuccessHandler.java
+++ b/src/main/java/com/codingbottle/calendar/domain/auth/handler/OAuth2MemberSuccessHandler.java
@@ -17,8 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.UUID;
 
 @Slf4j
 public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -56,44 +55,40 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
     private void redirect(HttpServletRequest request, HttpServletResponse response, Member member) throws IOException {
         log.info("OAuth2 Login Success!!");
 
-        String accessToken = delegateAccessToken(member);
-        String refreshToken = delegateRefreshToken(member);
-
-        String uri = createURI(accessToken, refreshToken).toString();
+        String uri = createURI().toString();
+        // TODO UUID 캐시에 넣을 때, <UUID, memberId> 형태로 저장하면 될 듯
         getRedirectStrategy().sendRedirect(request, response, uri);
     }
 
-    private String delegateAccessToken(Member member) {
-        Map<String, Object> claims = new HashMap<>();
-        claims.put("memberId", member.getId()); // memberId 값 넣음
-        claims.put("roles", member.getRole());
-
-        String audience = String.valueOf(member.getId()); // audience에 memberId 넣음
-
-        String accessToken = jwtTokenizer.generateAccessToken(claims, audience);
-
-        return accessToken;
-    }
-    private String delegateRefreshToken(Member member) {
-        String audience = String.valueOf(member.getId()); // audience에 memberId 넣음
-        String refreshToken = jwtTokenizer.generateRefreshToken(audience);
-
-        return refreshToken;
-    }
+//    private String delegateAccessToken(Member member) {
+//        Map<String, Object> claims = new HashMap<>();
+//        claims.put("memberId", member.getId()); // memberId 값 넣음
+//        claims.put("roles", member.getRole());
+//
+//        String audience = String.valueOf(member.getId()); // audience에 memberId 넣음
+//
+//        String accessToken = jwtTokenizer.generateAccessToken(claims, audience);
+//
+//        return accessToken;
+//    }
+//    private String delegateRefreshToken(Member member) {
+//        String audience = String.valueOf(member.getId()); // audience에 memberId 넣음
+//        String refreshToken = jwtTokenizer.generateRefreshToken(audience);
+//
+//        return refreshToken;
+//    }
 
     // OAuth2 로그인 성공 시 토큰값과 함께 반환될 URL 설정하는 부분
-    private URI createURI(String accessToken, String refreshToken) {
+    private URI createURI() {
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
-        queryParams.add("access_token", accessToken);
-        queryParams.add("refresh_token", refreshToken);
-
+        queryParams.add("oneTimeUseCode", UUID.randomUUID().toString()); // TODO 일회용 인증코드 나중에 캐시에 저장해야 함
 
         return UriComponentsBuilder
                 .newInstance()
                 .scheme("http")
                 .host("localhost")
-//                .port(80)
-                .path("/receive-token.html")
+                .port(3000)
+                .path("/oauth2/success")
                 .queryParams(queryParams)
                 .build()
                 .toUri();

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/controller/GoogleCalendarApiLocalController.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/controller/GoogleCalendarApiLocalController.java
@@ -1,7 +1,5 @@
 package com.codingbottle.calendar.domain.schedule.controller;
 
-import com.codingbottle.calendar.domain.schedule.service.CalendarApiIntegrationService;
-import com.google.api.services.calendar.Calendar;
 import com.google.api.client.auth.oauth2.AuthorizationCodeFlow;
 import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp;
@@ -9,6 +7,7 @@ import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.calendar.Calendar;
 import com.google.api.services.calendar.CalendarScopes;
 import com.google.api.services.calendar.model.Event;
 import com.google.api.services.calendar.model.Events;
@@ -33,12 +32,6 @@ public class GoogleCalendarApiLocalController {
     private String clientSecret;
     private static final List<String> SCOPES = Arrays.asList(CalendarScopes.CALENDAR);
     private static final String REDIRECT_URI = "http://localhost:8888/Callback"; // This should be the same as the one in the Google Cloud Console
-
-    private final CalendarApiIntegrationService calendarApiIntegrationService;
-
-    public GoogleCalendarApiLocalController(CalendarApiIntegrationService calendarApiIntegrationService) {
-        this.calendarApiIntegrationService = calendarApiIntegrationService;
-    }
 
     @GetMapping("/authorize-google")
     public String authorizeGoogle(@AuthenticationPrincipal String email) throws IOException {


### PR DESCRIPTION
## 요약
- 현재는 클라이언트가 인증 토큰을 발급받을 수 없으며, redirect url에서 query param을 활용할 수 있는지 확인한 다음, 일회용 인증코드로 토큰을 발급하도록 할 것.

## 추가사항
- 

## 수정사항
- OAuth2MemberSuccessHandler에서 잘못 설정된 Redirect url 변경.
