### PR TITLE
OAuth 인증 후 일회용 인증코드로 토큰 발급받기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ dependencies {
 	implementation group: 'com.google.http-client', name: 'google-http-client-jackson2', version: '1.43.3'
 	implementation group: 'com.google.oauth-client', name: 'google-oauth-client-jetty', version: '1.34.1'
 
+	// 캐싱
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.0.0'
 
 
 }

--- a/src/main/java/com/codingbottle/calendar/domain/auth/cache/OAuthOTUCache.java
+++ b/src/main/java/com/codingbottle/calendar/domain/auth/cache/OAuthOTUCache.java
@@ -1,0 +1,49 @@
+package com.codingbottle.calendar.domain.auth.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * OAuth 인증 중 서비스 서버가 발급한 일회용 인증코드를 담기 위한 캐시.
+ * 아래 OAuth 인증 절차의 5~6번 단계를 처리하기 위해 사용된다.
+ *
+ * 1. 웹브라우저에서 백엔드 서버에 최초 요청
+ * 2. 백엔드 서버는 요청을 받아서 OAuth 서버의 인증화면으로 리다이렉트시킴
+ * 3. 웹브라우저에서 인증이 완료되면 OAuth 서버가 웹브라우저에 백엔드 서버로 리다이렉트 응답 (이 때 리다이렉트 url의 쿼리 파라미터에 인증코드가 포함되어 있음)
+ * 4. 백엔드 서버는 리다이렉트된 요청을 받아 인증코드를 검증하고 최종적으로 사용자 정보를 얻는다.
+ *  - 이 단계가 마무리되면 실질적인 인증과 회원가입 절차는 끝났고, 웹브라우저에 인증토큰을 발급할 일만 남았음.
+ * 5. 이후 사용자를 프론트 서버로 다시 보내야 하므로, 프론트 도메인 주소로 리다이렉트시킨다.
+ *  이 때, 리다이렉트시의 쿼리 파라미터에 일회용 인증코드를 보낸다.
+ * 6. 프론트 서버는 일회용 인증코드를 백엔드 서버에 보내서 최종적으로 토큰을 발급받는다.
+ */
+@Component
+public class OAuthOTUCache {
+
+    // <verification code, memberId(in domain.member.entity.Member)>.
+    // thread-safe map.
+    private final Cache<String, Long> codeExpirationCache = Caffeine.newBuilder()
+            .expireAfterWrite(30, TimeUnit.SECONDS)
+            .build();
+
+    public String putVerificationCodeInCache(long targetMemberId) {
+        String verificationCode = UUID.randomUUID().toString();
+        codeExpirationCache.put(verificationCode, targetMemberId);
+
+        return verificationCode;
+    }
+
+    public long getMemberId(String verificationCode) {
+        if (!StringUtils.hasText(verificationCode)) {
+            throw new IllegalArgumentException("verificationCode must not be null or empty");
+        }
+        Long memberId = codeExpirationCache.getIfPresent(verificationCode);
+        codeExpirationCache.invalidate(verificationCode);
+        return Objects.requireNonNull(memberId, "verificationCode is invalid");
+    }
+}

--- a/src/main/java/com/codingbottle/calendar/domain/auth/controller/OAuthMemberController.java
+++ b/src/main/java/com/codingbottle/calendar/domain/auth/controller/OAuthMemberController.java
@@ -1,0 +1,28 @@
+package com.codingbottle.calendar.domain.auth.controller;
+
+import com.codingbottle.calendar.domain.auth.cache.OAuthOTUCache;
+import com.codingbottle.calendar.domain.auth.dto.response.TokenResponse;
+import com.codingbottle.calendar.domain.auth.jwt.JwtTokenizer;
+import com.codingbottle.calendar.domain.member.entity.Member;
+import com.codingbottle.calendar.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/oauth")
+public class OAuthMemberController {
+    private final OAuthOTUCache oAuthOTUCache;
+    private final JwtTokenizer jwtTokenizer;
+    private final MemberService memberService;
+
+    @GetMapping("/token")
+    public TokenResponse getToken(String code) {
+        long memberId = oAuthOTUCache.getMemberId(code);
+        Member member = memberService.getById(memberId);
+
+        return jwtTokenizer.generateTokens(member);
+    }
+}

--- a/src/main/java/com/codingbottle/calendar/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/codingbottle/calendar/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,24 @@
+package com.codingbottle.calendar.domain.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Date;
+
+@Getter
+@Builder
+public class TokenResponse {
+    private String authScheme;
+
+    private String accessToken;
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm:ss", timezone="Asia/Seoul")
+    private Date accessTokenExp;
+
+    private String refreshToken;
+    @JsonFormat(shape= JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm:ss", timezone="Asia/Seoul")
+    private Date refreshTokenExp;
+
+    private String username;
+    private String role;
+}

--- a/src/main/java/com/codingbottle/calendar/domain/auth/handler/OAuth2MemberFailureHandler.java
+++ b/src/main/java/com/codingbottle/calendar/domain/auth/handler/OAuth2MemberFailureHandler.java
@@ -5,6 +5,7 @@ import com.codingbottle.calendar.global.utils.ErrorResponder;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
@@ -12,6 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 // OAuth2 로그인 실패했을 때 동작하는 핸들러
+@Component
 @Slf4j
 public class OAuth2MemberFailureHandler extends SimpleUrlAuthenticationFailureHandler {
     @Override

--- a/src/main/java/com/codingbottle/calendar/domain/auth/handler/OAuth2MemberSuccessHandler.java
+++ b/src/main/java/com/codingbottle/calendar/domain/auth/handler/OAuth2MemberSuccessHandler.java
@@ -1,13 +1,13 @@
 package com.codingbottle.calendar.domain.auth.handler;
 
-import com.codingbottle.calendar.domain.auth.jwt.JwtTokenizer;
+import com.codingbottle.calendar.domain.auth.cache.OAuthOTUCache;
 import com.codingbottle.calendar.domain.member.entity.Member;
 import com.codingbottle.calendar.domain.member.service.MemberService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -17,18 +17,16 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URI;
-import java.util.UUID;
 
+@Component
 @Slf4j
 public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-    private final OAuth2AuthorizedClientService authorizedClientService;
     private final MemberService memberService;
-    private final JwtTokenizer jwtTokenizer;
+    private final OAuthOTUCache oAuthOTUCache;
 
-    public OAuth2MemberSuccessHandler(OAuth2AuthorizedClientService authorizedClientService, MemberService memberService, JwtTokenizer jwtTokenizer) {
-        this.authorizedClientService = authorizedClientService;
+    public OAuth2MemberSuccessHandler(MemberService memberService, OAuthOTUCache oAuthOTUCache) {
         this.memberService = memberService;
-        this.jwtTokenizer = jwtTokenizer;
+        this.oAuthOTUCache = oAuthOTUCache;
     }
 
     @Override
@@ -36,45 +34,23 @@ public class OAuth2MemberSuccessHandler extends SimpleUrlAuthenticationSuccessHa
         var oAuth2User = (OAuth2User) authentication.getPrincipal(); // 로그인 된 구글 계정 사용자 정보를 받아온다
         String email = String.valueOf(oAuth2User.getAttributes().get("email")); // 로그인 된 구글 계정 사용자의 이메일을 받아온다.
         String nickname = String.valueOf(oAuth2User.getAttributes().get("name")); // 닉네임 불러오기
-        // var authorizedClient = authorizedClientService.loadAuthorizedClient("google", authentication.getName());
 
-        memberService.oAuth2CheckMember(email, nickname); // 가입 되어 있으면 로그인, 없으면 회원가입
-
-        Member member = memberService.getMemberByEmail(email);
+        Member member = memberService.oAuth2CheckMember(email, nickname);// 가입 되어 있으면 로그인, 없으면 회원가입
         redirect(request, response, member);
-
     }
 
     private void redirect(HttpServletRequest request, HttpServletResponse response, Member member) throws IOException {
         log.info("OAuth2 Login Success!!");
+        String verificationCode = oAuthOTUCache.putVerificationCodeInCache(member.getId());
+        String uri = createURI(verificationCode).toString();
 
-        String uri = createURI().toString();
-        // TODO UUID 캐시에 넣을 때, <UUID, memberId> 형태로 저장하면 될 듯
         getRedirectStrategy().sendRedirect(request, response, uri);
     }
 
-//    private String delegateAccessToken(Member member) {
-//        Map<String, Object> claims = new HashMap<>();
-//        claims.put("memberId", member.getId()); // memberId 값 넣음
-//        claims.put("roles", member.getRole());
-//
-//        String audience = String.valueOf(member.getId()); // audience에 memberId 넣음
-//
-//        String accessToken = jwtTokenizer.generateAccessToken(claims, audience);
-//
-//        return accessToken;
-//    }
-//    private String delegateRefreshToken(Member member) {
-//        String audience = String.valueOf(member.getId()); // audience에 memberId 넣음
-//        String refreshToken = jwtTokenizer.generateRefreshToken(audience);
-//
-//        return refreshToken;
-//    }
-
     // OAuth2 로그인 성공 시 토큰값과 함께 반환될 URL 설정하는 부분
-    private URI createURI() {
+    private URI createURI(String verificationCode) {
         MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
-        queryParams.add("oneTimeUseCode", UUID.randomUUID().toString()); // TODO 일회용 인증코드 나중에 캐시에 저장해야 함
+        queryParams.add("oneTimeUseCode", verificationCode);
 
         return UriComponentsBuilder
                 .newInstance()

--- a/src/main/java/com/codingbottle/calendar/domain/member/controller/MemberController.java
+++ b/src/main/java/com/codingbottle/calendar/domain/member/controller/MemberController.java
@@ -6,20 +6,19 @@ import com.codingbottle.calendar.domain.member.service.MemberService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/members")
 public class MemberController {
     private final MemberService memberService;
     private final MemberMapper memberMapper;
-    private final OAuth2AuthorizedClientService authorizedClientService;
 
-    public MemberController(MemberService memberService, MemberMapper memberMapper, OAuth2AuthorizedClientService authorizedClientService) {
+    public MemberController(MemberService memberService, MemberMapper memberMapper) {
         this.memberService = memberService;
         this.memberMapper = memberMapper;
-        this.authorizedClientService = authorizedClientService;
     }
 
     // 로그인한 Member 정보 반환

--- a/src/main/java/com/codingbottle/calendar/global/test/TestMemberTokenProvider.java
+++ b/src/main/java/com/codingbottle/calendar/global/test/TestMemberTokenProvider.java
@@ -1,7 +1,9 @@
 package com.codingbottle.calendar.global.test;
 
+import com.codingbottle.calendar.domain.auth.cache.OAuthOTUCache;
 import com.codingbottle.calendar.domain.auth.jwt.JwtTokenizer;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,6 +14,7 @@ import java.util.List;
 @RestController
 public class TestMemberTokenProvider {
     private final JwtTokenizer jwtTokenizer;
+    private final OAuthOTUCache oAuthOTUCache;
 
     // 테스트 유저 (memberId: 1)의 토큰을 발급한다.
     @PostMapping("/test/token")
@@ -19,5 +22,10 @@ public class TestMemberTokenProvider {
         HashMap<String, Object> map = new HashMap<>();
         map.put("roles", List.of("USER"));
         return jwtTokenizer.generateAccessToken(map, "1");
+    }
+
+    @GetMapping("/test/otu-token")
+    public String testOtuToken() {
+        return oAuthOTUCache.putVerificationCodeInCache(1L);
     }
 }


### PR DESCRIPTION
## 요약
- OAuth 인증 후 일회용 인증코드로 토큰 발급받기
  - 이 기능을 추가한 이유에 대한 설명으로 OAuthOTUCache.java 파일의 클래스 상단 주석을 옮겨왔습니다.
```
/**
 * OAuth 인증 중 서비스 서버가 발급한 일회용 인증코드를 담기 위한 캐시.
 * 아래 OAuth 인증 절차의 5~6번 단계를 처리하기 위해 사용된다.
 *
 * 1. 웹브라우저에서 백엔드 서버에 최초 요청
 * 2. 백엔드 서버는 요청을 받아서 OAuth 서버의 인증화면으로 리다이렉트시킴
 * 3. 웹브라우저에서 인증이 완료되면 OAuth 서버가 웹브라우저에 백엔드 서버로 리다이렉트 응답 (이 때 리다이렉트 url의 쿼리 파라미터에 인증코드가 포함되어 있음)
 * 4. 백엔드 서버는 리다이렉트된 요청을 받아 인증코드를 검증하고 최종적으로 사용자 정보를 얻는다.
 *  - 이 단계가 마무리되면 실질적인 인증과 회원가입 절차는 끝났고, 웹브라우저에 인증토큰을 발급할 일만 남았음.
 * 5. 이후 사용자를 프론트 서버로 다시 보내야 하므로, 프론트 도메인 주소로 리다이렉트시킨다.
 *  이 때, 리다이렉트시의 쿼리 파라미터에 일회용 인증코드를 보낸다.
 * 6. 프론트 서버는 일회용 인증코드를 백엔드 서버에 보내서 최종적으로 토큰을 발급받는다.
 */
```

## 추가사항
- 캐싱 라이브러리 Caffeine 추가
- JwtTokenizer 클래스에 Access-Refresh를 한 번에 반환하는 generateTokens() API 추가

## 수정사항
- 리팩토링 (이유는 코드마다 댓글로 작성함)
