### PR TITLE
[Fix] 구글 캘린더 연동 수정

### DIFF
--- a/src/main/java/com/codingbottle/calendar/domain/schedule/service/CalendarApiIntegrationService.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/service/CalendarApiIntegrationService.java
@@ -149,7 +149,7 @@ public class CalendarApiIntegrationService {
         }
 
         ScheduleCreateReqDto scheduleCreateReqDto = new ScheduleCreateReqDto(
-                event.getSummary(),
+                event.getSummary() == null ? "제목 없음" : event.getSummary(),
                 startDate,
                 endDate,
                 isAllDay,


### PR DESCRIPTION
## 요약
- 구글 캘린더 이벤트를 받아 올 때 title 값이 null 값인 경우 "제목 없음"으로 저장되도록 설정

## 추가사항
- 없음

## 수정사항
- event.getSummary() == null ? "제목 없음" : event.getSummary() 삼항 연산자를 이용하여 수정
