### PR TITLE
[Update] 구글 캘린더 연동 기능 추가

### DIFF
--- a/src/main/java/com/codingbottle/calendar/domain/schedule/controller/GoogleCalendarApiServerController.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/controller/GoogleCalendarApiServerController.java
@@ -1,13 +1,12 @@
 package com.codingbottle.calendar.domain.schedule.controller;
 
 import com.codingbottle.calendar.domain.schedule.service.CalendarApiIntegrationService;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 @RestController
@@ -25,8 +24,8 @@ public class GoogleCalendarApiServerController {
     }
 
     @GetMapping("/callback")
-    public ResponseEntity callback(@RequestParam("code") String code) throws IOException {
+    public void callback(@RequestParam("code") String code, HttpServletResponse response) throws IOException {
         calendarApiIntegrationService.scheduleIntegration(code);
-        return new ResponseEntity(HttpStatus.OK);
+        response.sendRedirect("http://localhost:3000/test");
     }
 }

--- a/src/main/java/com/codingbottle/calendar/domain/schedule/service/CalendarApiIntegrationService.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/service/CalendarApiIntegrationService.java
@@ -13,6 +13,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.DateTime;
 import com.google.api.services.calendar.Calendar;
 import com.google.api.services.calendar.CalendarScopes;
 import com.google.api.services.calendar.model.Event;
@@ -23,7 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import java.io.IOException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -68,7 +68,7 @@ public class CalendarApiIntegrationService {
         Member member = memberService.getMemberByEmail(profile.getEmailAddresses().get(0).getValue());
 
         String pageToken = member.getCalendarApiIntegration().getLastPageToken();
-        Events events = calendarService.events().list("primary").setPageToken(pageToken).execute();
+        Events events = calendarService.events().list("primary").setTimeMin(DateTime.parseRfc3339("2023-12-01T00:00:00+09:00")).setPageToken(pageToken).execute();
         List<Event> items = events.getItems();
 
         String lastPageToken;


### PR DESCRIPTION
## 요약
- 2023년 12월 01일 부터 캘린더 연동되도록 설정(과거 데이터와 충돌 and 너무 많은 이벤트 조회 시 로딩 에러)
- 캘린더 연동 성공 시 http://localhost:3000/test로 리다이렉트 되도록 설정

## 추가사항
- .setTimeMin(DateTime.parseRfc3339("2023-12-01T00:00:00+09:00"))
- response.sendRedirect("http://localhost:3000/test");

## 수정사항
- 없음
