### PR TITLE
[Update] 구글 캘린더 연동 기능추가

### DIFF
--- a/src/main/java/com/codingbottle/calendar/domain/schedule/service/CalendarApiIntegrationService.java
+++ b/src/main/java/com/codingbottle/calendar/domain/schedule/service/CalendarApiIntegrationService.java
@@ -68,7 +68,11 @@ public class CalendarApiIntegrationService {
         Member member = memberService.getMemberByEmail(profile.getEmailAddresses().get(0).getValue());
 
         String pageToken = member.getCalendarApiIntegration().getLastPageToken();
-        Events events = calendarService.events().list("primary").setTimeMin(DateTime.parseRfc3339("2023-12-01T00:00:00+09:00")).setPageToken(pageToken).execute();
+        Events events = calendarService.events()
+                .list("primary")
+                .setTimeMin(DateTime.parseRfc3339("2023-12-01T00:00:00+09:00"))
+                .setPageToken(pageToken).execute()
+                .set("singleEvents", true);
         List<Event> items = events.getItems();
 
         String lastPageToken;


### PR DESCRIPTION
## 요약
- 반복일정과 삭제된 일정에서 event.getCreated().isDateOnly()가 null값으로 나오는 것을 발견, status가 cancelled된 일정은 불러오지 않도록 설정

## 추가사항
- .set("singleEvents", true)로 설정함으로써 반복일정에서 cancelled가 포함된 데이터를 받아오지 않도록 설정

## 수정사항
- 없습니다
